### PR TITLE
Fix crash when intent data can be null

### DIFF
--- a/TeaLeaf/src/com/tealeaf/TeaLeaf.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeaf.java
@@ -807,6 +807,9 @@ public class TeaLeaf extends FragmentActivity {
 
 	// TODO: can this be called after your activity is recycled, meaning we're never going to see these events?
 	protected void onActivityResult(int request, int result, Intent data) {
+		//We check whether data is null and return here to avoid crashes
+		//Happens when plugins calling this, send null
+		//Best way is to fix caller. The photopicker isn't used, so the best fix is to return on null
 		if (data == null) {
 			return;
 		}

--- a/TeaLeaf/src/com/tealeaf/TeaLeaf.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeaf.java
@@ -807,6 +807,9 @@ public class TeaLeaf extends FragmentActivity {
 
 	// TODO: can this be called after your activity is recycled, meaning we're never going to see these events?
 	protected void onActivityResult(int request, int result, Intent data) {
+		if (data == null) {
+			return;
+		}
 		super.onActivityResult(request, result, data);
 		PluginManager.callAll("onActivityResult", request, result, data);
 		logger.log("GOT ACTIVITY RESULT WITH", request, result);


### PR DESCRIPTION
Any of the plugins can be sending null and hence can result in crash.
We check for null and return silently.