### PR TITLE
Anr input event crash fix

### DIFF
--- a/TeaLeaf/src/com/tealeaf/TeaLeaf.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeaf.java
@@ -489,6 +489,12 @@ public class TeaLeaf extends FragmentActivity {
 		}
 	}
 
+	private class DispatcheventsAsync extends AsyncTask<String, Integer, String> {
+		protected String doInBackground(String... params) {
+			NativeShim.dispatchEvents(params);
+			return null;
+		}		
+	}
 	@Override
 	public void onWindowFocusChanged(boolean hasFocus) {
 		super.onWindowFocusChanged(hasFocus);
@@ -529,7 +535,7 @@ public class TeaLeaf extends FragmentActivity {
 
 				// DANGER: Calling dispatchEvents() is NOT thread-safe.
 				// Doing it here because the GLThread is paused.
-				NativeShim.dispatchEvents(events);
+				new DispatcheventsAsync().execute(events);
 			}
 		}
 	}
@@ -571,7 +577,7 @@ public class TeaLeaf extends FragmentActivity {
 
 						// DANGER: Calling dispatchEvents() is NOT thread-safe.
 						// Doing it here because the GLThread is paused.
-						NativeShim.dispatchEvents(events);
+						new DispatcheventsAsync().execute(events);
 					}
 					glView.setRendererStateReloading();
 				}

--- a/TeaLeaf/src/com/tealeaf/TeaLeaf.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeaf.java
@@ -533,8 +533,6 @@ public class TeaLeaf extends FragmentActivity {
 				//always send lost focus event
 				String[] events = {new WindowFocusLostEvent().pack()};
 
-				// DANGER: Calling dispatchEvents() is NOT thread-safe.
-				// Doing it here because the GLThread is paused.
 				new DispatcheventsAsync().execute(events);
 			}
 		}
@@ -575,8 +573,6 @@ public class TeaLeaf extends FragmentActivity {
 					if (jsRunning) {
 						String[] events = {new PauseEvent().pack()};
 
-						// DANGER: Calling dispatchEvents() is NOT thread-safe.
-						// Doing it here because the GLThread is paused.
 						new DispatcheventsAsync().execute(events);
 					}
 					glView.setRendererStateReloading();


### PR DESCRIPTION
Instead of running Nativedispatch on UI thread.Calling it in Async task is better option.